### PR TITLE
add react native event emitter methods

### DIFF
--- a/android/src/main/kotlin/com/scandit/datacapture/reactnative/core/ScanditDataCaptureCoreModule.kt
+++ b/android/src/main/kotlin/com/scandit/datacapture/reactnative/core/ScanditDataCaptureCoreModule.kt
@@ -368,6 +368,16 @@ class ScanditDataCaptureCoreModule(
         promise.resolve(camera.isTorchAvailable)
     }
 
+    @ReactMethod
+    fun addListener(eventName: String?) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Int?) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     override fun onFrameSourceDeserializationFinished(
         deserializer: FrameSourceDeserializer,
         frameSource: FrameSource,


### PR DESCRIPTION
Ever since React Native 65+, launching scandit produces quite a few warnings. Just wanted to request this change.

Examples of other packages:
https://github.com/software-mansion/react-native-reanimated/compare/2.2.0...2.2.1#diff-791d943e777c3aeed7f019e3261ef3f1447da24e60c47d7cc90f5d520121a00dR241

https://github.com/segmentio/analytics-react-native/blob/master/packages/sovran/android/src/main/java/com/reactnativesovran/SovranModule.kt#L35


RN 65 changelog:
https://www.reactnative.com/react-native-v0-65-x-released

I think this is the root cause on the above page:
> NativeEventEmitter no longer inherits from EventEmitter, so it no longer implements removeListener and removeSubscription. Instead, use the remove() method on the subscription object returned by addListener. ([d39643b9de](https://github.com/facebook/react-native/commit/d39643b9de11c6b44984166ede34a7f44de76fe5) by [@yungsters](https://github.com/yungsters))


<img width="850" alt="image" src="https://github.com/Scandit/scandit-react-native-datacapture-core/assets/30021449/b1f77aca-3d26-4d40-84bd-9a0607c20f91">

<img width="850" alt="image" src="https://github.com/Scandit/scandit-react-native-datacapture-core/assets/30021449/c87ad219-826b-4196-ad18-e65fd5673ef3">
