### PR TITLE
Patching for making Scandit work with RN New Arch Interop

### DIFF
--- a/ios/Sources/Utils/ReactNativeResult.swift
+++ b/ios/Sources/Utils/ReactNativeResult.swift
@@ -7,9 +7,10 @@
 import React
 import ScanditFrameworksCore
 
-public struct ReactNativeResult: FrameworksResult {
+public class ReactNativeResult: FrameworksResult {
     private let resolve: RCTPromiseResolveBlock
     private let rejecter: RCTPromiseRejectBlock
+    private var resolved: Bool = false
 
     public init(_ resolve: @escaping RCTPromiseResolveBlock,
                 _ reject: @escaping RCTPromiseRejectBlock) {
@@ -29,6 +30,7 @@ public struct ReactNativeResult: FrameworksResult {
             }
             return
         }
+        resolved = true
         resolve(object)
     }
 
@@ -38,6 +40,10 @@ public struct ReactNativeResult: FrameworksResult {
 
     public func reject(error: Error) {
         self.rejecter(String(error._code), error.localizedDescription, error as NSError)
+    }
+
+    public func isResolved() -> Bool {
+        resolved
     }
 }
 


### PR DESCRIPTION
This is needed to address this in React Native New Architecture

As for SparkScanViewManager, in NativeModule, view() function will be called multiple time and `postContainerCreateAction` will be called multiple time as part of that. ScanditDataCaptureSparkScan `create` function will retain to the already [resolved `ReactNativeResult` promise](https://github.com/Scandit/scandit-react-native-datacapture-barcode/blob/5f1f53ba2a0e8f82e2e14aa03de51b6ab571e5ed/ios/Sources/SparkScan/ScanditDataCaptureSparkScan.swift#L104-L110) chain resulting in error as shown in the screenshot.

![image](https://github.com/user-attachments/assets/443adcd3-b6d0-4921-85a7-7e4382f58962)
